### PR TITLE
Removes requirement for sinatra-activerecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'nokogiri'
 gem 'pg', '>=0.10.0'
 gem 'sqlite3-ruby', :require => 'sqlite3'
 gem 'activerecord'
-gem 'sinatra-activerecord'
 
 # Default random generator
 gem 'crypt-isaac'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,8 +148,6 @@ GEM
       rack (~> 1.3, >= 1.3.4)
       rack-protection (~> 1.1, >= 1.1.2)
       tilt (~> 1.3, >= 1.3.3)
-    sinatra-activerecord (0.1.3)
-      sinatra (>= 0.9.4)
     sprockets (2.0.3)
       hike (~> 1.2)
       rack (~> 1.0)
@@ -204,7 +202,6 @@ DEPENDENCIES
   shotgun
   shoulda-matchers
   sinatra
-  sinatra-activerecord
   sqlite3-ruby
   uuid
   vcr

--- a/lib/cas_fuji.rb
+++ b/lib/cas_fuji.rb
@@ -6,11 +6,9 @@ require 'uuid'
 require 'cgi'
 require 'ap'
 
-# Only load this if ActiveRecord hasn't already been loaded. If we
-# load sinatra-activerecord *after* ActiveRecord has already been
-# loaded, then it'll overwrite the existing db connection
-require 'sinatra/activerecord' unless defined?(ActiveRecord)
-
+require 'active_support/core_ext/string'
+require 'active_support/memoizable'
+require 'active_record'
 require 'addressable/uri'
 
 require 'cas_fuji/exception'
@@ -26,6 +24,8 @@ CasFuji.config[:authenticators].each do |authenticator|
   authenticator["source"] = authenticator["class"].underscore if authenticator["source"].nil?
   require authenticator["source"]
 end
+
+# ::ActiveRecord::Base.establish_connection(CasFuji.config[:database])
 
 require 'consumable'
 

--- a/lib/cas_fuji/models/base_ticket.rb
+++ b/lib/cas_fuji/models/base_ticket.rb
@@ -1,11 +1,13 @@
 module CasFuji
   module Models
     class BaseTicket < ActiveRecord::Base
-      establish_connection(CasFuji.config[:database])
+
+      ::ActiveRecord::Base.establish_connection(CasFuji.config[:database])
 
       def self.unique_ticket_name(ticket_type)
         "#{ ticket_type.upcase }-#{ ::UUID.new.generate }"
       end
+
     end
   end
 end


### PR DESCRIPTION
- Removes sinatra-activerecord from Gemfile
- Uses full reference to ActiveRecord::Base.establish_connection() in lib/cas_fuji/models/base_ticket.rb
- Requires active_support/core_ext/string in lib/cas_fuji.rb
- Requires activerecord/memoizable
