### PR TITLE
Updates yaml keys from strings to symbols

### DIFF
--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -10,8 +10,8 @@
     :permanent_id_column: permanent_id
     :extra_attributes: [email, first_name, last_name, locale]
   :authenticators:
-    - class: CasFuji::Authenticators::TestAuth
-      # source: lib/test_auth.rb
+    - :class: CasFuji::Authenticators::TestAuth
+      # :source: lib/test_auth.rb
   :organization:
     :name: Your Org Name
     :tagline: The name on the default login template

--- a/lib/cas_fuji.rb
+++ b/lib/cas_fuji.rb
@@ -21,8 +21,8 @@ require 'cas_fuji/authenticators/base'
 
 # Load the authenticators specified in the config file
 CasFuji.config[:authenticators].each do |authenticator|
-  authenticator["source"] = authenticator["class"].underscore if authenticator["source"].nil?
-  require authenticator["source"]
+  authenticator[:source] = authenticator[:class].underscore if authenticator[:source].nil?
+  require authenticator[:source]
 end
 
 # ::ActiveRecord::Base.establish_connection(CasFuji.config[:database])

--- a/lib/cas_fuji/app.rb
+++ b/lib/cas_fuji/app.rb
@@ -121,8 +121,9 @@ class CasFuji::App < Sinatra::Base
       }
 
       CasFuji.config[:authenticators].each do |authenticator|
-        permanent_id = authenticator["class"].constantize.validate(params)
-        return [authenticator["class"], permanent_id] if permanent_id
+          puts "AUTHENTICATOR #{authenticator.inspect}"
+        permanent_id = authenticator[:class].constantize.validate(params)
+        return [authenticator[:class], permanent_id] if permanent_id
       end
 
       return nil

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -94,17 +94,17 @@ describe CasFuji do
 
     context 'authenticated_user' do
       it 'should return a permanent id if credentials were valid' do
-        CasFuji.should_receive(:config).and_return({:authenticators => [{'class' => "DummyAuthenticator"}]})
+        CasFuji.should_receive(:config).and_return({:authenticators => [{:class => "DummyAuthenticator"}]})
         CasFuji::App.authenticate_user!("valid", "valid").should == ["DummyAuthenticator", "permanent_id"]
       end
 
       it 'should return nil if password is invalid' do
-        CasFuji.should_receive(:config).and_return({:authenticators => [{'class' => "DummyAuthenticator"}]})
+        CasFuji.should_receive(:config).and_return({:authenticators => [{:class => "DummyAuthenticator"}]})
         CasFuji::App.authenticate_user!("valid", "invalid").should be_nil
       end
 
       it 'should return nil if username is invalid' do
-        CasFuji.should_receive(:config).and_return({:authenticators => [{'class' => "DummyAuthenticator"}]})
+        CasFuji.should_receive(:config).and_return({:authenticators => [{:class => "DummyAuthenticator"}]})
         CasFuji::App.authenticate_user!("invalid", "valid").should be_nil
       end
     end


### PR DESCRIPTION
- Updates yaml field names from strings to symbols in config/config.sample.yml
- Updates lib/cas_fuji.rb to use symbols instead of strings, as keys to read config
- Updates lib/cas_fuji/app.rb to use symbols instead of strings, as keys to read config inside of authenticate_user!() method
- Updates spec/application_spec.rb to use symbols instead of strings, as keys for authenticators hash
